### PR TITLE
Testing new apply interface for Flux.Chain

### DIFF
--- a/src/Fluxperimental.jl
+++ b/src/Fluxperimental.jl
@@ -8,4 +8,7 @@ export Split, Join
 include("train.jl")
 export shinkansen!
 
+include("chain.jl")
+
+
 end # module Fluxperimental

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -1,37 +1,49 @@
 
-
+import Flux: ChainRulesCore
 # Some experiments with chain to start removing the need for recur to be mutable.
 # As per the conversation in the recurrent network rework issue.
 
 # Main difference between this and the _applychain function is we return a new chain
 # with the internal state modified as well as the output of applying x to the chain.
 apply(chain::Flux.Chain, x) = begin
-  layers, out = apply(chain.layers, x)
+  layers, out = _apply(chain.layers, x)
   Flux.Chain(layers), out
 end
 
-apply(layers::NamedTuple{NMS, TPS}, x) where {NMS, TPS} = begin
-  layers, out = apply(Tuple(layers), x)
+_apply(layers::NamedTuple{NMS, TPS}, x) where {NMS, TPS} = begin
+  layers, out = _apply(Tuple(layers), x)
   NamedTuple{NMS}(layers), out
 end
 
-function apply(layers::AbstractVector, x)  # type-unstable path, helps compile times
+function _scan(layers::AbstractVector, x)
   new_layers = typeof(layers)(undef, length(layers))
   for (idx, f) in enumerate(layers)
-    new_layers[idx], x = apply(f, x)
+    new_layers[idx], x = _apply_to_layer(f, x)
   end
   new_layers, x
 end
 
+function ChainRulesCore.rrule(::typeof(_scan), layers, x)
+  function _scan_pullback(dy)
+    throw("_scan Pullback not implemented")
+    return (ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent())
+  end
+  return _scan(layers, x), _scan_pullback
+end
+
+function _apply(layers::AbstractVector, x)  # type-unstable path, helps compile times
+  _scan(layers, x)
+end
+
 # Generated function returns a tuple of args and the last output of the network.
-@generated function apply(layers::Tuple{Vararg{<:Any,N}}, x) where {N}
+@generated function _apply(layers::Tuple{Vararg{<:Any,N}}, x) where {N}
   x_symbols = vcat(:x, [gensym() for _ in 1:N])
   l_symbols = [gensym() for _ in 1:N]
-  calls = [:(($(l_symbols[i]), $(x_symbols[i+1])) = apply(layers[$i], $(x_symbols[i]))) for i in 1:N]
+  calls = [:(($(l_symbols[i]), $(x_symbols[i+1])) = _apply_to_layer(layers[$i], $(x_symbols[i]))) for i in 1:N]
   push!(calls, :(return tuple($(l_symbols...)), $(x_symbols[end])))
   Expr(:block, calls...)
 end
 
-apply(layer, x) = layer, layer(x)
+_apply_to_layer(layer, x) = layer, layer(x)
 
 

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -5,12 +5,12 @@ import Flux: ChainRulesCore
 
 # Main difference between this and the _applychain function is we return a new chain
 # with the internal state modified as well as the output of applying x to the chain.
-apply(chain::Flux.Chain, x) = begin
+function apply(chain::Flux.Chain, x)
   layers, out = _apply(chain.layers, x)
   Flux.Chain(layers), out
 end
 
-_apply(layers::NamedTuple{NMS, TPS}, x) where {NMS, TPS} = begin
+function _apply(layers::NamedTuple{NMS, TPS}, x) where {NMS, TPS}
   layers, out = _apply(Tuple(layers), x)
   NamedTuple{NMS}(layers), out
 end
@@ -25,8 +25,7 @@ end
 
 function ChainRulesCore.rrule(::typeof(_scan), layers, x)
   function _scan_pullback(dy)
-    throw("_scan Pullback not implemented")
-    return (ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent())
+    error("_scan Pullback not implemented")
   end
   return _scan(layers, x), _scan_pullback
 end

--- a/src/chain.jl
+++ b/src/chain.jl
@@ -1,0 +1,37 @@
+
+
+# Some experiments with chain to start removing the need for recur to be mutable.
+# As per the conversation in the recurrent network rework issue.
+
+# Main difference between this and the _applychain function is we return a new chain
+# with the internal state modified as well as the output of applying x to the chain.
+apply(chain::Flux.Chain, x) = begin
+  layers, out = apply(chain.layers, x)
+  Flux.Chain(layers), out
+end
+
+apply(layers::NamedTuple{NMS, TPS}, x) where {NMS, TPS} = begin
+  layers, out = apply(Tuple(layers), x)
+  NamedTuple{NMS}(layers), out
+end
+
+function apply(layers::AbstractVector, x)  # type-unstable path, helps compile times
+  new_layers = typeof(layers)(undef, length(layers))
+  for (idx, f) in enumerate(layers)
+    new_layers[idx], x = apply(f, x)
+  end
+  new_layers, x
+end
+
+# Generated function returns a tuple of args and the last output of the network.
+@generated function apply(layers::Tuple{Vararg{<:Any,N}}, x) where {N}
+  x_symbols = vcat(:x, [gensym() for _ in 1:N])
+  l_symbols = [gensym() for _ in 1:N]
+  calls = [:(($(l_symbols[i]), $(x_symbols[i+1])) = apply(layers[$i], $(x_symbols[i]))) for i in 1:N]
+  push!(calls, :(return tuple($(l_symbols...)), $(x_symbols[end])))
+  Expr(:block, calls...)
+end
+
+apply(layer, x) = layer, layer(x)
+
+

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -71,5 +71,18 @@ end
       
       _grads_equal(grads_tuple, grads_truth)
     end
+
+    @test begin # Test Vector Gradient
+      c = Flux.Chain([l1, l2]) # named tuple Chain
+      grads_truth = Flux.gradient(Flux.params(c)) do
+        sum(c(x))
+      end
+
+      grads_tuple = Flux.gradient(Flux.params(c)) do
+        sum(Fluxperimental.apply(c, x)[end])
+      end
+      
+      _grads_equal(grads_tuple, grads_truth)
+    end
   end # @testset "Backward Pass"
 end # @testset "Applying the Chain!"

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -1,0 +1,29 @@
+
+import Flux, Fluxperimental
+
+@testset "Applying the Chain!" begin
+
+  x = rand(Float32, 10, 1)
+  l1 = Flux.Dense(10, 10)
+  l2 = Flux.Dense(10, 1)
+  truth = l2(l1(x))
+  
+  t_c = Flux.Chain(l1, l2) # tuple Chain
+  new_t_c, out = Fluxperimental.apply(t_c, x)
+  @test new_t_c[1] === l1 && new_t_c[2] === l2
+  @test all(out .== truth)
+  
+  
+  nt_c = Flux.Chain(l1=l1, l2=l2) # namedtuple Chain
+  new_nt_c, out = Fluxperimental.apply(nt_c, x)
+  @test new_nt_c[:l1] === l1 && new_nt_c[:l2] === l2
+  @test all(out .== truth)
+
+  
+  v_c = Flux.Chain([l1, l2]) # vector Chain
+  new_v_c, out = Fluxperimental.apply(nt_c, x)
+  @test new_v_c.layers[1] === l1 && new_v_c.layers[2] === l2
+  @test all(out .== truth)
+  
+    
+end

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -65,19 +65,17 @@ end
       _grads_equal(grads_tuple, grads_truth)
     end
       
-
-    
-    @test begin
-      v_c = Flux.Chain([l1, l2]) # vector Chain
-      grads_v_truth = Flux.gradient(Flux.params(v_c)) do
-        sum(v_c(x))
-      end
-      grads_vector = Flux.gradient(Flux.params(v_c)) do
-        sum(Fluxperimental.apply(v_c, x)[end])
-      end
+    # @test begin
+    #   v_c = Flux.Chain([l1, l2]) # vector Chain
+    #   grads_v_truth = Flux.gradient(Flux.params(v_c)) do
+    #     sum(v_c(x))
+    #   end
+    #   grads_vector = Flux.gradient(Flux.params(v_c)) do
+    #     sum(Fluxperimental.apply(v_c, x)[end])
+    #   end
       
-      _grads_equal(grads_vector, grads_v_truth)
-    end  skip=true
+    #   _grads_equal(grads_vector, grads_v_truth)
+    # end skip=true
     
 
     

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -1,29 +1,87 @@
 
 import Flux, Fluxperimental
 
+function _grads_equal(grads1, grads2)
+
+  if length(keys(grads1)) != length(keys(grads2))
+    return false
+  end
+  ret = true
+  for weights in keys(grads1)
+    if grads1[weights] isa AbstractArray
+      ret = ret && all(grads1[weights] .== grads2[weights])
+    elseif isnothing(grads1[weights])
+      ret = ret && isnothing(grads2[weights])
+    else
+      throw("Grad returned type $(typeof(grads1[weights]))")
+    end
+  end
+  return ret
+end
+
 @testset "Applying the Chain!" begin
 
-  x = rand(Float32, 10, 1)
-  l1 = Flux.Dense(10, 10)
-  l2 = Flux.Dense(10, 1)
-  truth = l2(l1(x))
-  
-  t_c = Flux.Chain(l1, l2) # tuple Chain
-  new_t_c, out = Fluxperimental.apply(t_c, x)
-  @test new_t_c[1] === l1 && new_t_c[2] === l2
-  @test all(out .== truth)
-  
-  
-  nt_c = Flux.Chain(l1=l1, l2=l2) # namedtuple Chain
-  new_nt_c, out = Fluxperimental.apply(nt_c, x)
-  @test new_nt_c[:l1] === l1 && new_nt_c[:l2] === l2
-  @test all(out .== truth)
+  @testset "Forward pass" begin
+    x = rand(Float32, 3, 1)
+    l1 = Flux.Dense(3, 4)
+    l2 = Flux.Dense(4, 1)
+    truth = l2(l1(x))
+    
+    t_c = Flux.Chain(l1, l2) # tuple Chain
+    new_t_c, out = Fluxperimental.apply(t_c, x)
+    @test new_t_c[1] === l1 && new_t_c[2] === l2
+    @test all(out .== truth)
+    
+    
+    nt_c = Flux.Chain(l1=l1, l2=l2) # namedtuple Chain
+    new_nt_c, out = Fluxperimental.apply(nt_c, x)
+    @test new_nt_c[:l1] === l1 && new_nt_c[:l2] === l2
+    @test all(out .== truth)
+
+    
+    v_c = Flux.Chain([l1, l2]) # vector Chain
+    new_v_c, out = Fluxperimental.apply(v_c, x)
+    @test new_v_c.layers[1] === l1 && new_v_c.layers[2] === l2
+    @test all(out .== truth)
+  end
+
+  @testset "Backward pass" begin
+    x = rand(Float32, 3, 1)
+    l1 = Flux.Dense(3, 4)
+    l2 = Flux.Dense(4, 1)
+    # truth = l2(l1(x))
+
+    
+    @test begin
+      t_c = Flux.Chain(l1, l2) # tuple Chain
+      grads_truth = Flux.gradient(Flux.params(t_c)) do
+        sum(t_c(x))
+      end
+
+      grads_tuple = Flux.gradient(Flux.params(t_c)) do
+        sum(Fluxperimental.apply(t_c, x)[end])
+      end
+      
+      _grads_equal(grads_tuple, grads_truth)
+    end
+      
+
+    
+    @test begin
+      v_c = Flux.Chain([l1, l2]) # vector Chain
+      grads_v_truth = Flux.gradient(Flux.params(v_c)) do
+        sum(v_c(x))
+      end
+      grads_vector = Flux.gradient(Flux.params(v_c)) do
+        sum(Fluxperimental.apply(v_c, x)[end])
+      end
+      
+      _grads_equal(grads_vector, grads_v_truth)
+    end  skip=true
+    
+
+    
+  end
 
   
-  v_c = Flux.Chain([l1, l2]) # vector Chain
-  new_v_c, out = Fluxperimental.apply(nt_c, x)
-  @test new_v_c.layers[1] === l1 && new_v_c.layers[2] === l2
-  @test all(out .== truth)
-  
-    
 end

--- a/test/chain.jl
+++ b/test/chain.jl
@@ -1,6 +1,3 @@
-
-import Flux, Fluxperimental
-
 function _grads_equal(grads1, grads2)
 
   if length(keys(grads1)) != length(keys(grads2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using Flux, Fluxperimental
 
 @testset "Fluxperimental.jl" begin
   include("split_join.jl")
+  include("chain.jl")
 end


### PR DESCRIPTION
New Feature:

Implemented new `apply` functionality which returns a newly constructed chain as well as the output of applying the input to the current chain. This is in relation to the recent conversation for updating the [recurrent network interface](https://github.com/FluxML/Flux.jl/issues/1678#issuecomment-1440987414). The apply was described by @ToucheSir.

Most of the code is a modification of the `_applychain` functionality from Flux.jl. The general direction is to likely interface with Accessors.jl. Some minor tests were added, but we will want to include many of the layer types as we expand the feature.

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
