### PR TITLE
Adapt `@compact` to work with minor change from JuliaSyntax.jl

### DIFF
--- a/src/compact.jl
+++ b/src/compact.jl
@@ -83,7 +83,7 @@ macro compact(fex, kwexs...)
   # check input
   Meta.isexpr(fex, :(->)) || error("expects a do block")
   isempty(kwexs) && error("expects keyword arguments")
-  all(ex -> Meta.isexpr(ex, :kw), kwexs) || error("expects only keyword argumens")
+  all(ex -> Meta.isexpr(ex, (:kw,:(=))), kwexs) || error("expects only keyword argumens")
 
   # check if user has named layer:
   name = findfirst(ex -> ex.args[1] == :name, kwexs)


### PR DESCRIPTION
The reference parser parses the `=` in `@x(y=1)` as `Expr(:(=))` but the `=` in `@x(y=1) do y end` as `Expr(:kw)`.  In JuliaSyntax, we've corrected this inconsistency as a minor change to the parsing rules, but this breaks the `@compact` macro in this package (And one macro in `ContextManagers` - the only two cases in General.)

Found as part of the integration work in https://github.com/JuliaLang/julia/pull/46372
