### PR TITLE
NewRecur experimental interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "3102ee7a-c841-4564-8f7f-ec69bd4fd658"
 version = "0.1.2"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"

--- a/src/Fluxperimental.jl
+++ b/src/Fluxperimental.jl
@@ -13,4 +13,6 @@ include("chain.jl")
 
 include("compact.jl")
 
+include("new_recur.jl")
+
 end # module Fluxperimental

--- a/src/new_recur.jl
+++ b/src/new_recur.jl
@@ -80,27 +80,4 @@ Flux.trainable(a::NewRecur) = (; cell = a.cell)
 Base.show(io::IO, m::NewRecur) = print(io, "Recur(", m.cell, ")")
 
 NewRNN(a...; return_sequence::Bool=false, ka...) = NewRecur(Flux.RNNCell(a...; ka...); return_sequence=return_sequence)
-# NewRecur(cell::Flux.RNNCell; return_sequence::Bool=false) = NewRecur(cell; return_sequence=return_sequence)
-
-# Quick Reset functionality
-
-# struct RecurWalk <: Flux.Functors.AbstractWalk end
-# (::RecurWalk)(recurse, x) = x isa Fluxperimental.NewRecur ? reset(x) : Flux.Functors.DefaultWalk()(recurse, x)
-
-# function reset(m::NewRecur{SEQ}) where SEQ
-#   NewRecur{SEQ}(m.cell, m.cell.state0)
-# end
-# reset(m) = m
-# function reset(m::Flux.Chain)
-#   ret = Flux.Functors.fmap((l)->l, m; walk=RecurWalk())
-# end
-
-
-##
-# Fallback apply timeseries data to other layers. Likely needs to be thoought through a bit more.
-##
-
-# function apply(l, xs::Union{AbstractVector{<:AbstractArray}, Base.Generator})
-#   l, [l(x) for x in xs]
-# end
 

--- a/src/new_recur.jl
+++ b/src/new_recur.jl
@@ -1,0 +1,106 @@
+
+
+"""
+  NewRecur
+New Recur. An experimental recur interface for removing statefullness in recurrent architectures for flux.
+"""
+struct NewRecur{RET_SEQUENCE, T}
+  cell::T
+  # state::S
+  function NewRecur(cell; return_sequence::Bool=false)
+    new{return_sequence, typeof(cell)}(cell)
+  end
+  function NewRecur{true}(cell)
+    new{true, typeof(cell)}(cell)
+  end
+  function NewRecur{false}(cell)
+    new{false, typeof(cell)}(cell)
+  end
+end
+
+# This is the same way we do 3-tensers from Flux.Recur
+function (m::NewRecur{false})(x::AbstractArray{T, N}, carry) where {T, N}
+  @assert N >= 3
+  # h = [m(x_t) for x_t in eachlastdim(x)]
+
+  cell = l.cell
+  x_init, x_rest = Iterators.peel(xs)
+  (carry, y) = cell(carry, x_init)
+  for x in x_rest
+    (carry, y) = cell(carry, x)
+  end
+  # carry, y
+  y
+
+end
+
+function (l::NewRecur{false})(x::AbstractArray{T, 3}, carry=l.cell.state0) where T
+  m(Flux.eachlastdim(x), carry)
+end
+
+function (l::NewRecur{false})(xs::Union{AbstractVector{<:AbstractArray}, Base.Generator},
+                              carry=l.cell.state0)
+  rnn = l.cell
+  # carry = layer.stamte
+  x_init, x_rest = Iterators.peel(xs)
+  (carry, y) = rnn(carry, x_init)
+  for x in x_rest
+    (carry, y) = rnn(carry, x)
+  end
+  y
+end
+
+# From Lux.jl: https://github.com/LuxDL/Lux.jl/pull/287/
+function (l::NewRecur{true})(xs::Union{AbstractVector{<:AbstractArray}, Base.Generator},
+                             carry=l.cell.state0)
+  rnn = l.cell
+  _xs = if xs isa Base.Generator
+    collect(xs)  # TODO: Fix. I can't figure out how to get around this for generators.
+  else
+    xs
+  end
+  x_init, _ = Iterators.peel(_xs)
+
+  (carry, out_) = rnn(carry, x_init)
+
+  init = (typeof(out_)[out_], carry)
+
+  function recurrence_op(input, (outputs, carry))
+    carry, out = rnn(carry, input)
+    return vcat(outputs, typeof(out)[out]), carry
+  end
+  results = foldr(recurrence_op, _xs[(begin+1):end]; init)
+  # return NewRecur{true}(rnn, results[1][end]), first(results)
+  first(results)
+end
+
+Flux.@functor NewRecur
+Flux.trainable(a::NewRecur) = (; cell = a.cell)
+
+Base.show(io::IO, m::NewRecur) = print(io, "Recur(", m.cell, ")")
+
+NewRNN(a...; return_sequence::Bool=false, ka...) = NewRecur(Flux.RNNCell(a...; ka...); return_sequence=return_sequence)
+# NewRecur(cell::Flux.RNNCell; return_sequence::Bool=false) = NewRecur(cell; return_sequence=return_sequence)
+
+# Quick Reset functionality
+
+# struct RecurWalk <: Flux.Functors.AbstractWalk end
+# (::RecurWalk)(recurse, x) = x isa Fluxperimental.NewRecur ? reset(x) : Flux.Functors.DefaultWalk()(recurse, x)
+
+# function reset(m::NewRecur{SEQ}) where SEQ
+#   NewRecur{SEQ}(m.cell, m.cell.state0)
+# end
+# reset(m) = m
+# function reset(m::Flux.Chain)
+#   ret = Flux.Functors.fmap((l)->l, m; walk=RecurWalk())
+# end
+
+
+##
+# Fallback apply timeseries data to other layers. Likely needs to be thoought through a bit more.
+##
+
+# function apply(l, xs::Union{AbstractVector{<:AbstractArray}, Base.Generator})
+#   l, [l(x) for x in xs]
+# end
+

--- a/src/new_recur.jl
+++ b/src/new_recur.jl
@@ -1,5 +1,6 @@
 
-
+import Flux: ChainRulesCore
+# import ChainRulesCore: rrule, HasReverseMode
 
 ##### Helper scan funtion which can likely be put into NNLib. #####
 """
@@ -8,27 +9,129 @@
 Recreating jax.lax.scan functionality in julia. Takes a function, initial carry and a sequence,
 then returns the output sequence and the final carry. 
 """
+
 function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
-  # get the first input to setup the initial state,
-  # get the rest of the input to run the fold over.
-  x_init, x_rest = Iterators.peel(xs)
-  # the following does the same as peel, but doesn't produce correct gradients?
-  ### x_init = first(xs)
-  ### x_rest = xs[begin+1:end]
-
-  # set up the initial state of the fold.
-  (carry_, out_) = func(init_carry, x_init)
-  init = (carry_, [out_])
-
-  # recurrence operation used in the fold. Takes the state  of the
-  # folde and the next input, returns the new state.
-  function __recurrence_op((carry, outputs), input)
-    carry, out = func(carry, input)
-    return carry, vcat(outputs, [out])
-  end
-  # Fold left to right.
-  foldl(__recurrence_op, x_rest; init)
+   # Recurrence operation used in the fold. Takes the state of the
+   # fold and the next input, returns the new state.
+   function recurrence_op((carry, outputs), input)
+       carry, out = func(carry, input)
+       return carry, vcat(outputs, [out])
+   end
+   # Fold left to right.
+   return Base.mapfoldl_impl(identity, recurrence_op, (init_carry, empty(xs)), xs)
 end
+
+function ChainRulesCore.rrule(
+  config::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasReverseMode},
+  ::typeof(Base.mapfoldl_impl),
+  ::typeof(identity),
+  op::G,
+  init,
+  x::Union{AbstractArray, Tuple};
+) where {G}
+  hobbits = Vector{Any}(undef, length(x))  # Unfornately Zygote needs this
+  accumulate!(hobbits, x; init=(init, nothing)) do (a, _), b
+  # hobbits = accumulate(x; init=(init, nothing)) do (a, _), b
+        c, back = ChainRulesCore.rrule_via_ad(config, op, a, b)
+    end
+    y = first(last(hobbits))
+    axe = axes(x)
+    project = ChainRulesCore.ProjectTo(x)
+    function unfoldl(dy)
+        trio = accumulate(Iterators.reverse(hobbits); init=(0, dy, 0)) do (_, dc, _), (_, back)
+            ds, da, db = back(dc)
+        end
+        dop = sum(first, trio)
+        dx = map(last, Iterators.reverse(trio))
+        d_init = trio[end][2]
+        return (ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent(), dop, d_init, project(reshape(dx, axe)))
+    end
+    return y, unfoldl
+end
+
+# function CRC.rrule(cfg::RuleConfig{>:HasReverseMode},
+#     ::typeof(Base.mapfoldl_impl),
+#     op::G,
+#     x::AbstractArray,
+#     init) where {G}
+#     list, start = x, init
+#     hobbits = Vector{Any}(undef, length(list))  # Unfornately Zygote needs this
+#     accumulate!(hobbits, list; init=(start, nothing)) do (a, _), b
+#         return CRC.rrule_via_ad(cfg, op, a, b)
+#     end
+#     y = first(last(hobbits))
+#     ax = axes(x)
+#     project = ChainRulesCore.ProjectTo(x)
+#     function ∇mapfoldl_impl(Δ)
+#         trio = accumulate(Iterators.reverse(hobbits); init=(0, Δ, 0)) do (_, dc, _), (_, back)
+#             return back(dc)
+#         end
+#         ∂op = sum(first, trio)
+#         ∂x = map(last, Iterators.reverse(trio))
+#         return (ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent(), dop, d_init, project(reshape(dx, axe))) #NoTangent(), ∂op, project(reshape(∂x, ax)), trio[end][2]
+#     end
+#     return y, ∇mapfoldl_impl
+# end
+
+
+
+# function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
+#   function __recurrence_op(::Tuple{Nothing, Nothing}, input)
+#     carry, out = func(init_carry, input)
+#     return carry, [out]
+#   end
+
+#   # recurrence operation used in the fold. Takes the state  of the
+#   function __recurrence_op((carry, outputs), input)
+#     carry, out = func(carry, input)
+#     return carry, vcat(outputs, [out])
+#   end
+
+#   # Fold left to right.
+#   foldl(__recurrence_op, xs; init=(nothing, nothing))
+# end
+
+# _cat_output(::Nothing, out) = [out]
+# _cat_output(outputs, out) = vcat(outputs, [out])
+
+# function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
+#   # Recurrence operation used in the fold. Takes the state of the
+#   # fold and the next input, returns the new state.
+#   function recurrence_op((carry, outputs), input)
+#     carry = ifelse(carry === nothing, init_carry, carry)
+#     carry, out = func(carry, input)
+#     return carry, _cat_output(outputs, out)
+#   end
+#   # Fold left to right.
+#   return foldl(recurrence_op, xs; init=(nothing, nothing))
+# end
+
+# function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
+#   # get the first input to setup the initial state,
+#   # get the rest of the input to run the fold over.
+#   # x_init, x_rest = Iterators.peel(xs)
+#   # the following does the same as peel, but doesn't produce correct gradients?
+#   ### x_init = first(xs)
+#   ### x_rest = xs[begin+1:end]
+
+#   # set up the initial state of the fold.
+#   # (carry_, out_) = func(init_carry, x_init)
+#   # init = (carry_, [out_])
+#   function __recurrence_op(::Nothing, input)
+#     carry, out = func(init_carry, input)
+#     return carry, [out]
+#   end
+
+#   # recurrence operation used in the fold. Takes the state  of the
+#   # folde and the next input, returns the new state.
+#   function __recurrence_op((carry, outputs), input)
+#     carry, out = func(carry, input)
+#     return carry, vcat(outputs, [out])
+#   end
+#   # Fold left to right.
+#   # foldl(__recurrence_op, xs; init=nothing)
+#   foldl_init(__recurrence_op, xs)
+# end
 
 function scan_full(func, init_carry, x_block)
   # x_block is an abstractarray and we want to scan over the last dimension.

--- a/src/new_recur.jl
+++ b/src/new_recur.jl
@@ -9,7 +9,6 @@ import Flux: ChainRulesCore
 Recreating jax.lax.scan functionality in julia. Takes a function, initial carry and a sequence,
 then returns the output sequence and the final carry. 
 """
-
 function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
    # Recurrence operation used in the fold. Takes the state of the
    # fold and the next input, returns the new state.
@@ -20,118 +19,6 @@ function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
    # Fold left to right.
    return Base.mapfoldl_impl(identity, recurrence_op, (init_carry, empty(xs)), xs)
 end
-
-function ChainRulesCore.rrule(
-  config::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasReverseMode},
-  ::typeof(Base.mapfoldl_impl),
-  ::typeof(identity),
-  op::G,
-  init,
-  x::Union{AbstractArray, Tuple};
-) where {G}
-  hobbits = Vector{Any}(undef, length(x))  # Unfornately Zygote needs this
-  accumulate!(hobbits, x; init=(init, nothing)) do (a, _), b
-  # hobbits = accumulate(x; init=(init, nothing)) do (a, _), b
-        c, back = ChainRulesCore.rrule_via_ad(config, op, a, b)
-    end
-    y = first(last(hobbits))
-    axe = axes(x)
-    project = ChainRulesCore.ProjectTo(x)
-    function unfoldl(dy)
-        trio = accumulate(Iterators.reverse(hobbits); init=(0, dy, 0)) do (_, dc, _), (_, back)
-            ds, da, db = back(dc)
-        end
-        dop = sum(first, trio)
-        dx = map(last, Iterators.reverse(trio))
-        d_init = trio[end][2]
-        return (ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent(), dop, d_init, project(reshape(dx, axe)))
-    end
-    return y, unfoldl
-end
-
-# function CRC.rrule(cfg::RuleConfig{>:HasReverseMode},
-#     ::typeof(Base.mapfoldl_impl),
-#     op::G,
-#     x::AbstractArray,
-#     init) where {G}
-#     list, start = x, init
-#     hobbits = Vector{Any}(undef, length(list))  # Unfornately Zygote needs this
-#     accumulate!(hobbits, list; init=(start, nothing)) do (a, _), b
-#         return CRC.rrule_via_ad(cfg, op, a, b)
-#     end
-#     y = first(last(hobbits))
-#     ax = axes(x)
-#     project = ChainRulesCore.ProjectTo(x)
-#     function ∇mapfoldl_impl(Δ)
-#         trio = accumulate(Iterators.reverse(hobbits); init=(0, Δ, 0)) do (_, dc, _), (_, back)
-#             return back(dc)
-#         end
-#         ∂op = sum(first, trio)
-#         ∂x = map(last, Iterators.reverse(trio))
-#         return (ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent(), dop, d_init, project(reshape(dx, axe))) #NoTangent(), ∂op, project(reshape(∂x, ax)), trio[end][2]
-#     end
-#     return y, ∇mapfoldl_impl
-# end
-
-
-
-# function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
-#   function __recurrence_op(::Tuple{Nothing, Nothing}, input)
-#     carry, out = func(init_carry, input)
-#     return carry, [out]
-#   end
-
-#   # recurrence operation used in the fold. Takes the state  of the
-#   function __recurrence_op((carry, outputs), input)
-#     carry, out = func(carry, input)
-#     return carry, vcat(outputs, [out])
-#   end
-
-#   # Fold left to right.
-#   foldl(__recurrence_op, xs; init=(nothing, nothing))
-# end
-
-# _cat_output(::Nothing, out) = [out]
-# _cat_output(outputs, out) = vcat(outputs, [out])
-
-# function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
-#   # Recurrence operation used in the fold. Takes the state of the
-#   # fold and the next input, returns the new state.
-#   function recurrence_op((carry, outputs), input)
-#     carry = ifelse(carry === nothing, init_carry, carry)
-#     carry, out = func(carry, input)
-#     return carry, _cat_output(outputs, out)
-#   end
-#   # Fold left to right.
-#   return foldl(recurrence_op, xs; init=(nothing, nothing))
-# end
-
-# function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
-#   # get the first input to setup the initial state,
-#   # get the rest of the input to run the fold over.
-#   # x_init, x_rest = Iterators.peel(xs)
-#   # the following does the same as peel, but doesn't produce correct gradients?
-#   ### x_init = first(xs)
-#   ### x_rest = xs[begin+1:end]
-
-#   # set up the initial state of the fold.
-#   # (carry_, out_) = func(init_carry, x_init)
-#   # init = (carry_, [out_])
-#   function __recurrence_op(::Nothing, input)
-#     carry, out = func(init_carry, input)
-#     return carry, [out]
-#   end
-
-#   # recurrence operation used in the fold. Takes the state  of the
-#   # folde and the next input, returns the new state.
-#   function __recurrence_op((carry, outputs), input)
-#     carry, out = func(carry, input)
-#     return carry, vcat(outputs, [out])
-#   end
-#   # Fold left to right.
-#   # foldl(__recurrence_op, xs; init=nothing)
-#   foldl_init(__recurrence_op, xs)
-# end
 
 function scan_full(func, init_carry, x_block)
   # x_block is an abstractarray and we want to scan over the last dimension.
@@ -145,6 +32,34 @@ function scan_full(func, init_carry, x_block)
     xs_
   end
   scan_full(func, init_carry, xs)
+end
+
+# Chain Rule for Base.mapfoldl_impl
+function ChainRulesCore.rrule(
+  config::ChainRulesCore.RuleConfig{>:ChainRulesCore.HasReverseMode},
+  ::typeof(Base.mapfoldl_impl),
+  ::typeof(identity),
+  op::G,
+  init,
+  x::Union{AbstractArray, Tuple};
+) where {G}
+  hobbits = Vector{Any}(undef, length(x))  # Unfornately Zygote needs this
+  accumulate!(hobbits, x; init=(init, nothing)) do (a, _), b
+    c, back = ChainRulesCore.rrule_via_ad(config, op, a, b)
+  end
+  y = first(last(hobbits))
+  axe = axes(x)
+  project = ChainRulesCore.ProjectTo(x)
+  function unfoldl(dy)
+    trio = accumulate(Iterators.reverse(hobbits); init=(0, dy, 0)) do (_, dc, _), (_, back)
+      ds, da, db = back(dc)
+    end
+    dop = sum(first, trio)
+    dx = map(last, Iterators.reverse(trio))
+    d_init = trio[end][2]
+    return (ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent(), dop, d_init, project(reshape(dx, axe)))
+  end
+  return y, unfoldl
 end
 
 

--- a/src/new_recur.jl
+++ b/src/new_recur.jl
@@ -1,5 +1,6 @@
 
 import Flux: ChainRulesCore
+import Compat: stack
 # import ChainRulesCore: rrule, HasReverseMode
 
 ##### Helper scan funtion which can likely be put into NNLib. #####

--- a/src/new_recur.jl
+++ b/src/new_recur.jl
@@ -5,9 +5,7 @@ import Compat: stack
 """
   scan_full
 
-Recreating jax.lax.scan functionality in julia. Takes a function, initial carry and a sequence,
-then returns the full output of the sequence and the final carry. See `scan_partial` to only 
-return the final output of the sequence. 
+Recreating jax.lax.scan functionality in julia. Takes a function, initial carry and a sequence, then returns the full output of the sequence and the final carry. See `scan_partial` to only return the final output of the sequence. 
 """
 function scan_full(func, init_carry, xs::AbstractVector{<:AbstractArray})
   # Recurrence operation used in the fold. Takes the state of the
@@ -66,9 +64,7 @@ end
 """
   scan_partial
 
-Recreating jax.lax.scan functionality in julia. Takes a function, initial carry and a sequence,
-then returns the final output of the sequence and the final carry. See `scan_full` to return 
-the entire output sequence.
+Recreating jax.lax.scan functionality in julia. Takes a function, initial carry and a sequence, then returns the final output of the sequence and the final carry. See `scan_full` to return the entire output sequence.
 """
 function scan_partial(func, init_carry, xs::AbstractVector{<:AbstractArray})
   x_init, x_rest = Iterators.peel(xs)
@@ -96,10 +92,7 @@ end
 
 """
   NewRecur
-New Recur. An experimental recur interface for removing statefullness in recurrent architectures for flux.
-This struct has two type parameters. The first `RET_SEQUENCE` is a boolean which determines whether `scan_full` 
-(`RET_SEQUENCE=true`) or `scan_partial` (`RET_SEQUENCE=false`) is used to scan through the sequence. This
-structure has no internal state, and instead returns:
+New Recur. An experimental recur interface for removing statefullness in recurrent architectures for flux. This struct has two type parameters. The first `RET_SEQUENCE` is a boolean which determines whether `scan_full` (`RET_SEQUENCE=true`) or `scan_partial` (`RET_SEQUENCE=false`) is used to scan through the sequence. This structure has no internal state, and instead returns:
 
 ```julia
 l = NewRNN(1,2)

--- a/src/new_recur.jl
+++ b/src/new_recur.jl
@@ -1,7 +1,5 @@
-
 import Flux: ChainRulesCore
 import Compat: stack
-# import ChainRulesCore: rrule, HasReverseMode
 
 ##### Helper scan funtion which can likely be put into NNLib. #####
 """
@@ -131,10 +129,6 @@ function (l::NewRecur{false})(init_carry, xs)
 end
 
 function (l::NewRecur{true})(init_carry, xs)
-
   results = scan_full(l.cell, init_carry, xs)
   results[1], stack(results[2], dims=3)
 end
-
-
-

--- a/test/new_recur.jl
+++ b/test/new_recur.jl
@@ -13,9 +13,9 @@
     # @show layer(x)
     @test eltype(layer(x)) <: Float32
     @test size(layer(x)) == (1, 1, 2)
-    @test size(layer([2.0f0])) == (1, )
 
-    @test_throws ErrorException layer([2.0f0;; 3.0f0])
+    @test_throws MethodError layer([2.0f0])
+    @test_throws MethodError layer([2.0f0;; 3.0f0])
   end
 
 
@@ -103,9 +103,10 @@ end
 
     @test eltype(layer(x)) <: Float32
     @test size(layer(x)) == (1, 1)
-    @test size(layer([2.0f0])) == (1, )
-
-    @test_throws ErrorException layer([2.0f0;; 3.0f0])
+    
+    @test_throws MethodError layer([2.0f0])
+    @test_throws MethodError layer([2.0f0;; 3.0f0])
+    
   end
 
   @testset "gradients-implicit" begin

--- a/test/new_recur.jl
+++ b/test/new_recur.jl
@@ -1,0 +1,111 @@
+
+
+@testset "RNN gradients-implicit" begin
+  cell = Flux.RNNCell(1, 1, identity)
+  layer = Flux.Recur(cell)
+  layer.cell.Wi .= 5.0
+  layer.cell.Wh .= 4.0
+  layer.cell.b .= 0.0f0
+  layer.cell.state0 .= 7.0
+  x = [[2.0f0], [3.0f0]]
+
+  # theoretical primal gradients
+  primal =
+    layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
+    x[2] .* layer.cell.Wi
+  ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
+  ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
+  ∇b = layer.cell.Wh .+ 1
+  ∇state0 = layer.cell.Wh .^ 2
+
+  nm_layer = Fluxperimental.NewRecur(cell; return_sequence = true)
+  ps = Flux.params(nm_layer)
+  e, g = Flux.withgradient(ps) do
+    out = nm_layer(x)
+    sum(out[2])
+  end
+  
+  @test primal[1] ≈ e
+  @test ∇Wi ≈ g[ps[1]]
+  @test ∇Wh ≈ g[ps[2]]
+  @test ∇b ≈ g[ps[3]]
+  @test ∇state0 ≈ g[ps[4]]
+end
+
+@testset "RNN gradients-implicit-partial sequence" begin
+  cell = Flux.RNNCell(1, 1, identity)
+  layer = Flux.Recur(cell)
+  layer.cell.Wi .= 5.0
+  layer.cell.Wh .= 4.0
+  layer.cell.b .= 0.0f0
+  layer.cell.state0 .= 7.0
+  x = [[2.0f0], [3.0f0]]
+
+  # theoretical primal gradients
+  primal =
+    layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
+    x[2] .* layer.cell.Wi
+  ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
+  ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
+  ∇b = layer.cell.Wh .+ 1
+  ∇state0 = layer.cell.Wh .^ 2
+
+  nm_layer = Fluxperimental.NewRecur(cell; return_sequence = false)
+  ps = Flux.params(nm_layer)
+  e, g = Flux.withgradient(ps) do
+    out = (nm_layer)(x)
+    sum(out)
+  end
+  
+  @test primal[1] ≈ e
+  @test ∇Wi ≈ g[ps[1]]
+  @test ∇Wh ≈ g[ps[2]]
+  @test ∇b ≈ g[ps[3]]
+  @test ∇state0 ≈ g[ps[4]]
+end
+
+@testset "RNN gradients-explicit partial sequence" begin
+
+
+  cell = Flux.RNNCell(1, 1, identity)
+  layer = Flux.Recur(cell)
+  layer.cell.Wi .= 5.0
+  layer.cell.Wh .= 4.0
+  layer.cell.b .= 0.0f0
+  layer.cell.state0 .= 7.0
+  x = [[2.0f0], [3.0f0]]
+
+  # theoretical primal gradients
+  primal =
+    layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
+    x[2] .* layer.cell.Wi
+  ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
+  ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
+  ∇b = layer.cell.Wh .+ 1
+  ∇state0 = layer.cell.Wh .^ 2
+
+
+
+  nm_layer = Fluxperimental.NewRecur(cell; return_sequence = false)
+  e, g = Flux.withgradient(nm_layer) do layer
+    # r_l = Fluxperimental.reset(layer)
+    out = layer(x)
+    sum(out)
+  end
+  grads = g[1][:cell]
+
+  @test primal[1] ≈ e
+
+  if VERSION < v"1.7"
+    @test ∇Wi ≈ grads[:Wi]
+    @test ∇Wh ≈ grads[:Wh]
+    @test ∇b ≈ grads[:b]
+    @test ∇state0 ≈ grads[:state0]
+  else
+    @test ∇Wi ≈ grads[:Wi]
+    @test ∇Wh ≈ grads[:Wh]
+    @test ∇b ≈ grads[:b]
+    @test ∇state0 ≈ grads[:state0]
+  end
+end
+

--- a/test/new_recur.jl
+++ b/test/new_recur.jl
@@ -1,111 +1,181 @@
 
 
-@testset "RNN gradients-implicit" begin
-  cell = Flux.RNNCell(1, 1, identity)
-  layer = Flux.Recur(cell)
-  layer.cell.Wi .= 5.0
-  layer.cell.Wh .= 4.0
-  layer.cell.b .= 0.0f0
-  layer.cell.state0 .= 7.0
-  x = [[2.0f0], [3.0f0]]
+@testset "NewRecur RNN" begin
+  @testset "Forward Pass" begin
+    cell = Flux.RNNCell(1, 1, identity)
+    layer = Fluxperimental.NewRecur(cell; return_sequence=true)
+    layer.cell.Wi .= 5.0
+    layer.cell.Wh .= 4.0
+    layer.cell.b .= 0.0f0
+    layer.cell.state0 .= 7.0
+    x = reshape([2.0f0, 3.0f0], 1, 1, 2)
 
-  # theoretical primal gradients
-  primal =
-    layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
-    x[2] .* layer.cell.Wi
-  ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
-  ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
-  ∇b = layer.cell.Wh .+ 1
-  ∇state0 = layer.cell.Wh .^ 2
+    # @show layer(x)
+    @test eltype(layer(x)) <: Float32
+    @test size(layer(x)) == (1, 1, 2)
+    @test size(layer([2.0f0])) == (1, )
 
-  nm_layer = Fluxperimental.NewRecur(cell; return_sequence = true)
-  ps = Flux.params(nm_layer)
-  e, g = Flux.withgradient(ps) do
-    out = nm_layer(x)
-    sum(out[2])
+    @test_throws ErrorException layer([2.0f0;; 3.0f0])
   end
-  
-  @test primal[1] ≈ e
-  @test ∇Wi ≈ g[ps[1]]
-  @test ∇Wh ≈ g[ps[2]]
-  @test ∇b ≈ g[ps[3]]
-  @test ∇state0 ≈ g[ps[4]]
-end
 
-@testset "RNN gradients-implicit-partial sequence" begin
-  cell = Flux.RNNCell(1, 1, identity)
-  layer = Flux.Recur(cell)
-  layer.cell.Wi .= 5.0
-  layer.cell.Wh .= 4.0
-  layer.cell.b .= 0.0f0
-  layer.cell.state0 .= 7.0
-  x = [[2.0f0], [3.0f0]]
 
-  # theoretical primal gradients
-  primal =
-    layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
-    x[2] .* layer.cell.Wi
-  ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
-  ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
-  ∇b = layer.cell.Wh .+ 1
-  ∇state0 = layer.cell.Wh .^ 2
+  @testset "gradients-implicit" begin
+    cell = Flux.RNNCell(1, 1, identity)
+    layer = Flux.Recur(cell)
+    layer.cell.Wi .= 5.0
+    layer.cell.Wh .= 4.0
+    layer.cell.b .= 0.0f0
+    layer.cell.state0 .= 7.0
+    x = [[2.0f0], [3.0f0]]
 
-  nm_layer = Fluxperimental.NewRecur(cell; return_sequence = false)
-  ps = Flux.params(nm_layer)
-  e, g = Flux.withgradient(ps) do
-    out = (nm_layer)(x)
-    sum(out)
+    # theoretical primal gradients
+    primal =
+      layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
+      x[2] .* layer.cell.Wi
+    ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
+    ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
+    ∇b = layer.cell.Wh .+ 1
+    ∇state0 = layer.cell.Wh .^ 2
+
+    nm_layer = Fluxperimental.NewRecur(cell; return_sequence = true)
+    ps = Flux.params(nm_layer)
+    x_block = reshape(vcat(x...), 1, 1, length(x))
+    e, g = Flux.withgradient(ps) do
+      out = nm_layer(x_block)
+      sum(out[1, 1, 2])
+    end
+    
+    @test primal[1] ≈ e
+    @test ∇Wi ≈ g[ps[1]]
+    @test ∇Wh ≈ g[ps[2]]
+    @test ∇b ≈ g[ps[3]]
+    @test ∇state0 ≈ g[ps[4]]
   end
-  
-  @test primal[1] ≈ e
-  @test ∇Wi ≈ g[ps[1]]
-  @test ∇Wh ≈ g[ps[2]]
-  @test ∇b ≈ g[ps[3]]
-  @test ∇state0 ≈ g[ps[4]]
-end
-
-@testset "RNN gradients-explicit partial sequence" begin
 
 
-  cell = Flux.RNNCell(1, 1, identity)
-  layer = Flux.Recur(cell)
-  layer.cell.Wi .= 5.0
-  layer.cell.Wh .= 4.0
-  layer.cell.b .= 0.0f0
-  layer.cell.state0 .= 7.0
-  x = [[2.0f0], [3.0f0]]
+  @testset "gradients-explicit" begin
 
-  # theoretical primal gradients
-  primal =
-    layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
-    x[2] .* layer.cell.Wi
-  ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
-  ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
-  ∇b = layer.cell.Wh .+ 1
-  ∇state0 = layer.cell.Wh .^ 2
+    cell = Flux.RNNCell(1, 1, identity)
+    layer = Flux.Recur(cell)
+    layer.cell.Wi .= 5.0
+    layer.cell.Wh .= 4.0
+    layer.cell.b .= 0.0f0
+    layer.cell.state0 .= 7.0
+    x = [[2.0f0], [3.0f0]]
+
+    # theoretical primal gradients
+    primal =
+      layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
+      x[2] .* layer.cell.Wi
+    ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
+    ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
+    ∇b = layer.cell.Wh .+ 1
+    ∇state0 = layer.cell.Wh .^ 2
 
 
+    x_block = reshape(vcat(x...), 1, 1, length(x))
+    nm_layer = Fluxperimental.NewRecur(cell; return_sequence = true)
+    e, g = Flux.withgradient(nm_layer) do layer
+      out = layer(x_block)
+      sum(out[1, 1, 2])
+    end
+    grads = g[1][:cell]
 
-  nm_layer = Fluxperimental.NewRecur(cell; return_sequence = false)
-  e, g = Flux.withgradient(nm_layer) do layer
-    # r_l = Fluxperimental.reset(layer)
-    out = layer(x)
-    sum(out)
-  end
-  grads = g[1][:cell]
-
-  @test primal[1] ≈ e
-
-  if VERSION < v"1.7"
+    @test primal[1] ≈ e
     @test ∇Wi ≈ grads[:Wi]
     @test ∇Wh ≈ grads[:Wh]
     @test ∇b ≈ grads[:b]
     @test ∇state0 ≈ grads[:state0]
-  else
+    
+  end
+end
+
+@testset "New Recur RNN Partial Sequence" begin
+
+  @testset "Forward Pass" begin
+    cell = Flux.RNNCell(1, 1, identity)
+    layer = Fluxperimental.NewRecur(cell)
+    layer.cell.Wi .= 5.0
+    layer.cell.Wh .= 4.0
+    layer.cell.b .= 0.0f0
+    layer.cell.state0 .= 7.0
+    x = reshape([2.0f0, 3.0f0], 1, 1, 2)
+
+    @test eltype(layer(x)) <: Float32
+    @test size(layer(x)) == (1, 1)
+    @test size(layer([2.0f0])) == (1, )
+
+    @test_throws ErrorException layer([2.0f0;; 3.0f0])
+  end
+
+  @testset "gradients-implicit" begin
+    cell = Flux.RNNCell(1, 1, identity)
+    layer = Flux.Recur(cell)
+    layer.cell.Wi .= 5.0
+    layer.cell.Wh .= 4.0
+    layer.cell.b .= 0.0f0
+    layer.cell.state0 .= 7.0
+    x = [[2.0f0], [3.0f0]]
+
+    # theoretical primal gradients
+    primal =
+      layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
+      x[2] .* layer.cell.Wi
+    ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
+    ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
+    ∇b = layer.cell.Wh .+ 1
+    ∇state0 = layer.cell.Wh .^ 2
+
+    nm_layer = Fluxperimental.NewRecur(cell; return_sequence = false)
+    ps = Flux.params(nm_layer)
+    x_block = reshape(vcat(x...), 1, 1, length(x))
+    e, g = Flux.withgradient(ps) do
+      out = (nm_layer)(x_block)
+      sum(out)
+    end
+    
+    @test primal[1] ≈ e
+    @test ∇Wi ≈ g[ps[1]]
+    @test ∇Wh ≈ g[ps[2]]
+    @test ∇b ≈ g[ps[3]]
+    @test ∇state0 ≈ g[ps[4]]
+  end
+
+  @testset "gradients-explicit" begin
+
+
+    cell = Flux.RNNCell(1, 1, identity)
+    layer = Flux.Recur(cell)
+    layer.cell.Wi .= 5.0
+    layer.cell.Wh .= 4.0
+    layer.cell.b .= 0.0f0
+    layer.cell.state0 .= 7.0
+    x = [[2.0f0], [3.0f0]]
+
+    # theoretical primal gradients
+    primal =
+      layer.cell.Wh .* (layer.cell.Wh * layer.cell.state0 .+ x[1] .* layer.cell.Wi) .+
+      x[2] .* layer.cell.Wi
+    ∇Wi = x[1] .* layer.cell.Wh .+ x[2]
+    ∇Wh = 2 .* layer.cell.Wh .* layer.cell.state0 .+ x[1] .* layer.cell.Wi
+    ∇b = layer.cell.Wh .+ 1
+    ∇state0 = layer.cell.Wh .^ 2
+
+
+    x_block = reshape(vcat(x...), 1, 1, length(x))
+    nm_layer = Fluxperimental.NewRecur(cell; return_sequence = false)
+    e, g = Flux.withgradient(nm_layer) do layer
+      out = layer(x_block)
+      sum(out)
+    end
+    grads = g[1][:cell]
+
+    @test primal[1] ≈ e
     @test ∇Wi ≈ grads[:Wi]
     @test ∇Wh ≈ grads[:Wh]
     @test ∇b ≈ grads[:b]
     @test ∇state0 ≈ grads[:state0]
+
   end
 end
 

--- a/test/new_recur.jl
+++ b/test/new_recur.jl
@@ -1,5 +1,3 @@
-
-
 @testset "NewRecur RNN" begin
   @testset "Forward Pass" begin
     # tanh is needed for forward check to determine ordering of inputs.
@@ -93,12 +91,10 @@
     @test ∇Wh ≈ grads[:Wh]
     @test ∇b ≈ grads[:b]
     @test ∇state0 ≈ grads[:state0]
-    
   end
 end
 
 @testset "New Recur RNN Partial Sequence" begin
-
   @testset "Forward Pass" begin
     cell = Flux.RNNCell(1, 1, identity)
     layer = Fluxperimental.NewRecur(cell)
@@ -121,7 +117,6 @@ end
     
     @test_throws MethodError layer([2.0f0])
     @test_throws MethodError layer([2.0f0;; 3.0f0])
-    
   end
 
   @testset "gradients-implicit" begin
@@ -158,8 +153,6 @@ end
   end
 
   @testset "gradients-explicit" begin
-
-
     cell = Flux.RNNCell(1, 1, identity)
     layer = Flux.Recur(cell)
     layer.cell.Wi .= 5.0
@@ -177,7 +170,6 @@ end
     ∇b = layer.cell.Wh .+ 1
     ∇state0 = layer.cell.Wh .^ 2
 
-
     x_block = reshape(vcat(x...), 1, 1, length(x))
     nm_layer = Fluxperimental.NewRecur(cell; return_sequence = false)
     e, g = Flux.withgradient(nm_layer) do layer
@@ -194,4 +186,3 @@ end
 
   end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,11 @@ using Test
 using Flux, Fluxperimental
 
 @testset "Fluxperimental.jl" begin
-  # include("split_join.jl")
+  include("split_join.jl")
 
-  # include("chain.jl")
+  include("chain.jl")
 
-  # include("compact.jl")
+  include("compact.jl")
 
   include("new_recur.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,11 @@ using Test
 using Flux, Fluxperimental
 
 @testset "Fluxperimental.jl" begin
-  include("split_join.jl")
+  # include("split_join.jl")
 
-  include("chain.jl")
+  # include("chain.jl")
 
-  include("compact.jl")
+  # include("compact.jl")
 
   include("new_recur.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,6 @@ using Flux, Fluxperimental
 
   include("compact.jl")
 
+  include("new_recur.jl")
+
 end


### PR DESCRIPTION
Adding NewRecur as proposed in https://github.com/FluxML/Flux.jl/issues/2258. This does indeed fix the gradient issues in explicit mode.

Added Features
- `NewRecur{SEQ}` which implements the interface proposed by @ToucheSir.
- Tested gradients of the NewRecur.

Issues:
- Have no solution to return the state of the network to the user currently. Might not be simple, and I don't think forcing users to wrap everything in several parallel streams is a viable option interface wise.
- Have not tested with passing in carry to the cell, but it should work pretty easily.

Thoughts:
- I prefer the interface worked on for the new chain interface we worked on several months ago to this. I think that provides a way for us to return the carry a bit easier, but there might be problems still there (see #7). 
- I think taking the state out of the network is necessary, but if we do this we should go all in on the idea, and incorporate the change into `Chain` instead of forcing the user to manage the network structure.

### PR Checklist

- [x] Tests are added
- ~[ ] Documentation, if applicable~
