### PR TITLE
Remove `@compact(name=...)` and replace with `NoShow` 

### DIFF
--- a/src/Fluxperimental.jl
+++ b/src/Fluxperimental.jl
@@ -13,6 +13,9 @@ include("chain.jl")
 
 include("compact.jl")
 
+include("noshow.jl")
+export NoShow
+
 include("new_recur.jl")
 
 end # module Fluxperimental

--- a/src/compact.jl
+++ b/src/compact.jl
@@ -68,6 +68,7 @@ for epoch in 1:1000
   Flux.train!((m,x,y) -> (m(x) - y)^2, model, data, optim)
 end
 ```
+To specify a custom printout for the model, you may find [`NoShow`](@ref) useful.
 """
 macro compact(_exs...)
   # check inputs, extracting function expression fex and unprocessed keyword arguments _kwexs

--- a/src/compact.jl
+++ b/src/compact.jl
@@ -156,7 +156,7 @@ function Flux._big_show(io::IO, obj::CompactLayer, indent::Int=0, name=nothing)
   setup_strings = obj.setup_strings
     layer, input, block = obj.strings
     pre, post = ("(", ")")
-    println(io, " "^indent, "@compact", pre)
+    println(io, " "^indent, isnothing(name) ? "" : "$name = ", layer, pre)
     for k in keys(obj.variables)
       v = obj.variables[k]
       if Flux._show_leaflike(v)

--- a/src/noshow.jl
+++ b/src/noshow.jl
@@ -21,16 +21,16 @@ Chain(
   Dense(9 => 10),                       # 100 parameters
 )                   # Total: 8 arrays, 145 parameters, 1.191 KiB.
 
-julia> PseudoLayer((i,o)::Pair) = NoShow(
-                                    "PseudoLayer(\$i => \$o)",
+julia> pseudolayer((i,o)::Pair) = NoShow(
+                                    "pseudolayer(\$i => \$o)",
                                     Parallel(+, Dense(i => o, relu), Dense(i => o, tanh)),
                                   )
-PseudoLayer (generic function with 1 method)
+pseudolayer (generic function with 1 method)
 
-julia> Chain(Dense(2 => 3), PseudoLayer(3 => 10), Dense(9 => 10))
+julia> Chain(Dense(2 => 3), pseudolayer(3 => 10), Dense(9 => 10))
 Chain(
   Dense(2 => 3),                        # 9 parameters
-  PseudoLayer(3 => 10),                 # 80 parameters
+  pseudolayer(3 => 10),                 # 80 parameters
   Dense(9 => 10),                       # 100 parameters
 )                   # Total: 8 arrays, 189 parameters, 1.379 KiB.
 ```
@@ -40,13 +40,13 @@ struct NoShow{T}
     layer::T
 end
 
-NoShow(layer) = NoShow("", layer)
+NoShow(layer) = NoShow("NoShow(...)", layer)
 
 Flux.@functor NoShow
 
 (no::NoShow)(x...) = no.layer(x...)
 
-Base.show(io::IO, no::NoShow) = print(io, isempty(no.str) ? "NoShow(...)" : no.str)
+Base.show(io::IO, no::NoShow) = print(io, no.str)
 
 Flux._show_leaflike(::NoShow) = true  # I think this is right
 Flux._show_children(::NoShow) = (;)   # Seems to be needed?

--- a/src/noshow.jl
+++ b/src/noshow.jl
@@ -21,11 +21,13 @@ Chain(
   Dense(9 => 10),                       # 100 parameters
 )                   # Total: 8 arrays, 145 parameters, 1.191 KiB.
 
-julia> PseudoLayer((i,o)::Pair) = Parallel(+, Dense(i => o, relu), Dense(i => o, tanh));
+julia> PseudoLayer((i,o)::Pair) = NoShow(
+                                    "PseudoLayer(\$i => \$o)",
+                                    Parallel(+, Dense(i => o, relu), Dense(i => o, tanh)),
+                                  )
+PseudoLayer (generic function with 1 method)
 
-julia> mid = PseudoLayer(3 => 10);
-
-julia> Chain(Dense(2 => 3), NoShow("PseudoLayer(3 => 10)", mid), Dense(9 => 10))
+julia> Chain(Dense(2 => 3), PseudoLayer(3 => 10), Dense(9 => 10))
 Chain(
   Dense(2 => 3),                        # 9 parameters
   PseudoLayer(3 => 10),                 # 80 parameters

--- a/src/noshow.jl
+++ b/src/noshow.jl
@@ -1,0 +1,60 @@
+
+"""
+    NoShow(layer)
+    NoShow(string, layer)
+
+This alters printing (for instance at the REPL prompt) to let you hide the complexity
+of some part of a Flux model. It has no effect on the actual running of the model.
+
+By default it prints `NoShow(...)` instead of the given layer.
+If you provide a string, it prints that instead -- it can be anything,
+but it may make sense to print the name of a function which will
+re-create the same structure.
+
+# Examples
+
+```jldoctest
+julia> Chain(Dense(2 => 3), NoShow(Parallel(vcat, Dense(3 => 4), Dense(3 => 5))), Dense(9 => 10))
+Chain(
+  Dense(2 => 3),                        # 9 parameters
+  NoShow(...),                          # 36 parameters
+  Dense(9 => 10),                       # 100 parameters
+)                   # Total: 8 arrays, 145 parameters, 1.191 KiB.
+
+julia> PseudoLayer((i,o)::Pair) = Parallel(+, Dense(i => o, relu), Dense(i => o, tanh));
+
+julia> mid = PseudoLayer(3 => 10);
+
+julia> Chain(Dense(2 => 3), NoShow("PseudoLayer(3 => 10)", mid), Dense(9 => 10))
+Chain(
+  Dense(2 => 3),                        # 9 parameters
+  PseudoLayer(3 => 10),                 # 80 parameters
+  Dense(9 => 10),                       # 100 parameters
+)                   # Total: 8 arrays, 189 parameters, 1.379 KiB.
+```
+"""
+struct NoShow{T}
+    str::String
+    layer::T
+end
+
+NoShow(layer) = NoShow("", layer)
+
+Flux.@functor NoShow
+
+(no::NoShow)(x...) = no.layer(x...)
+
+Base.show(io::IO, no::NoShow) = print(io, isempty(no.str) ? "NoShow(...)" : no.str)
+
+Flux._show_leaflike(::NoShow) = true  # I think this is right
+Flux._show_children(::NoShow) = (;)   # Seems to be needed?
+
+function Base.show(io::IO, ::MIME"text/plain", m::NoShow)
+  if get(io, :typeinfo, nothing) === nothing  # e.g., top level of REPL
+    Flux._big_show(io, m)
+  elseif !get(io, :compact, false)  # e.g., printed inside a Vector, but not a matrix
+    Flux._layer_show(io, m)
+  else
+    show(io, m)
+  end
+end

--- a/test/compact.jl
+++ b/test/compact.jl
@@ -139,28 +139,6 @@ end
     @test similar_strings(get_model_string(model2), expected_string)
   end
 
-#=  # This test is broken:
-
-julia> model1 = @compact(w1=Dense(32=>32, relu), w2=Dense(32=>32, relu)) do x
-             w2(w1(x));
-
-julia> model2 = @compact(w1=model1, w2=Dense(32=>32, relu)) do x
-             w2(w1(x))
-           end
-@compact(
-  @compact(
-    w1 = Dense(32 => 32, relu),         # 1_056 parameters
-    w2 = Dense(32 => 32, relu),         # 1_056 parameters
-  ) do x 
-      w2(w1(x))
-  end,
-  w2 = Dense(32 => 32, relu),           # 1_056 parameters
-) do x 
-    w2(w1(x))
-end                  # Total: 6 arrays, 3_168 parameters, 13.239 KiB.
-
-=#
-
   @testset "Array parameters" begin
     model = @compact(x=randn(32), w=Dense(32=>32)) do s
       w(x .* s)
@@ -212,3 +190,13 @@ end                  # Total: 6 arrays, 3_168 parameters, 13.239 KiB.
   end
 end
 
+
+@testset "Custom naming of @compact with NoShow" begin
+  _model = @compact(w=Dense(32, 32)) do x, y
+    tmp = sum(w(x))
+    return tmp + y
+  end
+  model = NoShow(_model) 
+  expected_string = "NoShow(...)         # 1_056 parameters"
+  @test similar_strings(get_model_string(model), expected_string)
+end

--- a/test/compact.jl
+++ b/test/compact.jl
@@ -200,5 +200,5 @@ end
   expected_string = "NoShow(...)         # 1_056 parameters"
   @test similar_strings(get_model_string(model), expected_string)
   model2 = NoShow("test", _model)
-  @test similar_strings(get_model_string(model2), "test")
+  @test contains(get_model_string(model2), "test")
 end

--- a/test/compact.jl
+++ b/test/compact.jl
@@ -199,4 +199,6 @@ end
   model = NoShow(_model) 
   expected_string = "NoShow(...)         # 1_056 parameters"
   @test similar_strings(get_model_string(model), expected_string)
+  model2 = NoShow("test", _model)
+  @test similar_strings(get_model_string(model2), "test")
 end

--- a/test/compact.jl
+++ b/test/compact.jl
@@ -101,7 +101,7 @@ end
       (1, 128),
       (1,),
     ]
-    @test size(model(randn(n_in, 32))) == (1, 32)
+    @test size(model(randn(Float32, n_in, 32))) == (1, 32)
   end
 
   @testset "String representations" begin

--- a/test/noshow.jl
+++ b/test/noshow.jl
@@ -1,0 +1,28 @@
+
+@testset "NoShow" begin
+  d23 = Dense(2 => 3)
+  d34 = Dense(3 => 4, tanh)
+  d35 = Dense(3 => 5, relu)
+  d910 = Dense(9 => 10)
+
+  model = Chain(d23, Parallel(vcat, d34, d35), d910)
+  m_no = Chain(d23, NoShow(Parallel(vcat, d34, NoShow("zzz", d35))), d910)
+
+  @test sum(length, Flux.params(model)) == sum(length, Flux.params(m_no))
+
+  xin = randn(Float32, 2, 7)
+  @test model(xin) ≈ m_no(xin)
+
+  # gradients
+  grad = gradient(m -> m(xin)[1], model)[1]
+  g_no = gradient(m -> m(xin)[1], m_no)[1]
+
+  @test grad.layers[2].layers[1].bias ≈ g_no.layers[2].layer.layers[1].bias
+  @test grad.layers[2].layers[2].bias ≈ g_no.layers[2].layer.layers[2].layer.bias
+
+  # printing -- see also compact.jl for another test
+  @test !contains(string(model), "NoShow(...)")
+  @test contains(string(m_no), "NoShow(...)")
+  @test !contains(string(m_no), "3 => 4")
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Flux, Fluxperimental
   include("chain.jl")
 
   include("compact.jl")
+  include("noshow.jl")
 
   include("new_recur.jl")
 


### PR DESCRIPTION
As part of trying to simplify `@compact`, this removes the special keyword `name`, which replaced all printing with a given string. (This probably needs to be part of a breaking change.)

The problem that solved was that sometimes the default `show` prints a lot. That's not really specific to `@compact`. So perhaps it can be more cleanly addressed by making something orthogonal... so the second commit makes a trivial `NoShow` layer which does this.

~~`NoShow` needs tests.~~

Edit: Note that master is 0.2 since https://github.com/FluxML/Fluxperimental.jl/pull/16 but had not been released yet. 