### PR TITLE
Change `@autostruct` to allow type restrictions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Fluxperimental"
 uuid = "3102ee7a-c841-4564-8f7f-ec69bd4fd658"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/test/autostruct.jl
+++ b/test/autostruct.jl
@@ -1,6 +1,6 @@
 Fluxperimental.DEFINE |> empty!
 
-@autostruct function New1(a)
+@autostruct function New1(a::Int)
     A = Dense(a => 2a)
     New1(A)
 end
@@ -16,7 +16,7 @@ end
 
 id1 = string(New1)  # something like "var\"##New1#265\""
 
-@autostruct function New1(a)  # re-definition of constructor, same struct!
+@autostruct function New1(a::Int)  # re-definition of constructor, same struct!
     A = Dense(2a => a, tanh)
     New1(A)
 end
@@ -33,7 +33,7 @@ end
 
 @autostruct :expand function New1(a, b=3)  # new struct, both for :expand and for b argument
     A = Dense(a => b)
-    New1(A)
+    New1(A::Dense)
 end
 
 @testset "new defn" begin


### PR DESCRIPTION
This changes #22 to remove the `nothing` fields, and leaves managing ambiguities up to you. 

It also allows type restrictions like `return MyLayer(a::Dense, b::Vector)` which are applied to the struct defn. 
