### PR TITLE
A bit more `@autostruct`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Fluxperimental"
 uuid = "3102ee7a-c841-4564-8f7f-ec69bd4fd658"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/autostruct.jl
+++ b/src/autostruct.jl
@@ -147,7 +147,6 @@ function _autostruct(expr; expand::Bool=false)
     end
     funargs = expr.args[1].args[2:end]
     retargs = ret.args[2:end]
-    @show funargs retargs
     if length(retargs) == length(funargs) && all(ex -> ex isa Symbol, retargs) && all(ex -> ex isa Symbol, funargs)
         # This check only catches cases like MyFun(a) -> MyFun(A), not MyFun(as...) or MyFun(a, b=1) or MyFun(a; b=1)
         @warn "Function $(expr.args[1]) will be ambiguous with struct $ret. " *

--- a/src/autostruct.jl
+++ b/src/autostruct.jl
@@ -15,7 +15,8 @@ Usually, the steps to define a new one are:
 
 Given the function in step 2, this macro handles step 1. You still do step 3.
 
-If you change the name or types of the fields, then the `struct` definition is automatically replaced.
+If you change the name or types of the fields, then the `struct` definition is
+automatically replaced, without re-starting Julia.
 This works because this definition uses an auto-generated name, which is `== MyLayer`.
 (But existing instances of the old `struct` are not changed in any way!)
 
@@ -54,8 +55,8 @@ struct MyModel001{T1, T2}
 end
 ```
 
-Since this can hold any objects, even `MyModel("hello", "world")`, 
-as you can see by looking `methods(MyModel)`, there should never be an ambiguity
+This can hold any objects, even `MyModel("hello", "world")`.
+As you can see by looking `methods(MyModel)`, there should never be an ambiguity
 between the `struct`'s own constructor, and your `MyModel(d::Int)`.
 
 You can also restrict the types allowed in the struct:
@@ -78,6 +79,17 @@ struct MyOtherModel001{T1 <: Embedding, T2 <: Dense}
   gamma::T1
   delta::T2
 end
+```
+
+If you need to add additional constructor methods, the obvious syntax will not work.
+But you can add them to the type, like this:
+
+```julia
+MyModel(str::String) = MyModel(parse(Int, str))
+# ERROR: cannot define function MyModel; it already has a value
+
+(::Type{MyModel})(str::String) = MyModel(parse(Int, str))
+MyModel("4")  # this works
 ```
 
 ## Compared to `@compact`

--- a/src/autostruct.jl
+++ b/src/autostruct.jl
@@ -23,6 +23,9 @@ This works because this definition uses an auto-generated name, which is `== MyL
 Writing `@autostruct :expand function MyLayer(d)` will use `@layer :expand MyLayer`,
 and result in container-style pretty-printing.
 
+See [AutoStructs.jl](https://github.com/CarloLucibello/AutoStructs.jl) for
+a version of this macro aimed at non-Flux uses.
+
 ## Examples
 
 ```julia

--- a/test/autostruct.jl
+++ b/test/autostruct.jl
@@ -45,3 +45,14 @@ end
     @test contains(repr("text/plain", m3), "New1(\n")
     @test contains(repr("text/plain", m3), "Dense(3 => 3)")
 end
+
+@autostruct One(field::Dense)
+
+@testset "no-function" begin
+    m1 = One(Dense(2=>3))
+    @test Flux.state(m1).field.bias == zeros(Float32, 3)
+    @test_throws MethodError One(3)
+    # pretty printing
+    @test contains(repr("text/plain", m1), "One(\n")
+    @test contains(repr("text/plain", m1), "Dense(2 => 3)")
+end


### PR DESCRIPTION
This adds a warning if your constructor and type will be ambiguous. Only in the most obvious cases, but something:
```julia
julia> @autostruct function New1(a)
           A = Dense(a => 2a)
           New1(A)
       end
┌ Warning: Function New1(a) will be ambiguous with struct New1(A). Please add some type restrictions to the function, or to the return line (which sets struct fields)
└ @ Fluxperimental ~/.julia/dev/Fluxperimental/src/autostruct.jl:152
var"##New1#547"

julia> New1(1)
ERROR: MethodError: no method matching *(::Int64, ::Dense{typeof(identity), Matrix{Float32}, Vector{Float32}})
Stacktrace:
 [1] var"##New1#547"(a::Dense{typeof(identity), Matrix{Float32}, Vector{Float32}})
   @ Main ./REPL[212]:2
 [2] var"##New1#547"(a::Int64)
   @ Main ./REPL[212]:3

julia> @autostruct function New1(a)
           A = Dense(a => 2a)
           New1(A::Dense)
       end
var"##New1#551"

julia> New1(1)
New1(...)           # 4 parameters
```
Edit, now also allows `@autostruct` without the function. If you just want a struct (e.g. to hold other layers) but not a constructor function, then this still lets you change the definition:

```julia
julia> @autostruct New2(aye, bee::Function)
var"##New2#562"

julia> New2(Dense(3=>3), sin)
New2(
  Dense(3 => 3),                        # 12 parameters
  sin,
) 
```