### PR TITLE
Adjust `@ompact` for Flux 0.15

### DIFF
--- a/src/Fluxperimental.jl
+++ b/src/Fluxperimental.jl
@@ -12,6 +12,7 @@ export shinkansen!
 include("chain.jl")
 
 include("compact.jl")
+export @compact
 
 include("noshow.jl")
 export NoShow

--- a/src/compact.jl
+++ b/src/compact.jl
@@ -139,7 +139,7 @@ end
 CompactLayer(f::Function, str::Tuple, setup_str::NamedTuple; kw...) = CompactLayer(f, str, setup_str, NamedTuple(kw))
 (m::CompactLayer)(x...) = m.fun(m.variables, x...)
 CompactLayer(args...) = error("CompactLayer is meant to be constructed by the macro")
-Flux.@functor CompactLayer
+Flux.Functors.@functor CompactLayer
 
 Flux._show_children(m::CompactLayer) = m.variables
 


### PR DESCRIPTION
This avoids `Flux.@functor` as that will be noisy on Flux 0.15. 

6eb318f86f6940faeabb3b696ded3f105387d995 was on master instead of this branch, by mistake.

Also exports `@compact` because why not.